### PR TITLE
Fix/missing attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mix-manifest.json
 composer.lock
 .phpunit.result.cache
 .php-cs-fixer.cache
+.DS_Store

--- a/src/Listeners/PushToWebhook.php
+++ b/src/Listeners/PushToWebhook.php
@@ -76,7 +76,7 @@ class PushToWebhook
                 ];
             }
             
-            // unset($data[$handle]);
+            unset($data[$handle]);
         }
 
         foreach($data as $name => $value) {

--- a/src/Listeners/PushToWebhook.php
+++ b/src/Listeners/PushToWebhook.php
@@ -37,10 +37,8 @@ class PushToWebhook
         $webhookUrl = config('statamic.zapier.force_url') ?? $webhookUrl;
 
         // all data
-        $data = $event->submission->data();
+        $data = clone $event->submission->data();
         $data['submission_id'] = $event->submission->id();
-
-        // dd($event->submission->data(), $event->submission->fields());
 
         // filter out the attachments
         $attachmentsFields = $event->submission->fields()->filter(function ($value, $key) use ($data) {

--- a/src/Listeners/PushToWebhook.php
+++ b/src/Listeners/PushToWebhook.php
@@ -40,8 +40,6 @@ class PushToWebhook
         $data = $event->submission->data();
         $data['submission_id'] = $event->submission->id();
 
-        // dd($event->submission->data(), $event->submission->fields());
-
         // filter out the attachments
         $attachmentsFields = $event->submission->fields()->filter(function ($value, $key) use ($data) {
             return is_array($value) && isset($value['type']) && $value['type'] == "assets" && isset($data[$key]) && $data[$key] != null;
@@ -78,7 +76,7 @@ class PushToWebhook
                 ];
             }
             
-            unset($data[$handle]);
+            // unset($data[$handle]);
         }
 
         foreach($data as $name => $value) {


### PR DESCRIPTION
Clone original form data object to stop it from being overwritten. This fixes an issues that caused all form attachments to be emptied after the Zapier webhook call.